### PR TITLE
Fixed lexing of floats that end in a dot and parsing of notes that come before the opening "{" of a struct

### DIFF
--- a/cmd/src/main.jai
+++ b/cmd/src/main.jai
@@ -1,37 +1,33 @@
-find_current_jai_path :: () -> string {
-
-    remove_trailing_slash :: (path: string) -> string {
-        result := path;
-        if path[path.count - 1] == #char "/" result.count -= 1;
-        return result;
-    }
-
+get_import_paths :: () -> []string {
     Compiler :: #import "Compiler";
     options := Compiler.get_build_options();
-    for options.import_path {
-        print("Module: %\n", it);
 
-        if find_index_from_left(to_lower_copy_new(it), "jai/modules") != -1 {
-            modules_path := remove_trailing_slash(it);
-            base_path := remove_trailing_slash(path_strip_filename(modules_path));
-            log("% -> %", modules_path, base_path);
-            return base_path;
-        }
-    }
+    paths: [..]string;
 
-    return "";
+    for options.import_path
+        array_add(*paths, trim_right(it, "/"));
+
+    print("Import path is: %", paths);
+
+    return paths;
 }
 
-JAI_PATH :: #run find_current_jai_path();
-JAI_MODULES_PATH :: #run tprint("%/modules", JAI_PATH);
+IMPORT_PATHS :: #run get_import_paths();
 
 get_module_entry :: (root: string) -> string {
-    uri := tprint("%/module.jai", root);
-    if !file_exists(uri) {
-        uri = tprint("%.jai", root);
+    for IMPORT_PATHS{
+        uri := tprint("%/%/module.jai", it, root);
+        
+        if file_exists(uri)
+            return uri;
+
+        uri = tprint("%/%.jai", it, root);
+        
+        if file_exists (uri)
+            return uri;
     }
 
-    return uri;
+    return root;
 }
 
 pool: Pool;
@@ -80,8 +76,7 @@ node_visit :: (node: *Node, data: Node_Visit_Data) {
 
         if _import.import_kind == {
             case .MODULE;
-                module_path := tprint("%/%", JAI_MODULES_PATH, _import.module);
-                path = get_module_entry(module_path);
+                path = get_module_entry(_import.module);
             case .FILE;
                 path = tprint("%/%", data.path_without_filename, _import.module); 
             case .DIR;
@@ -107,7 +102,6 @@ parse_file :: (files: *Files, path: string) {
     }
 
     path_without_filename := trim_right(path_strip_filename(path), "/");
-    print("Parsing file %...\n", path);
 
     parser: Parser(Node_Visit_Data);
     parser.user_data = .{
@@ -131,8 +125,6 @@ parse_file :: (files: *Files, path: string) {
 }
 
 main :: () {
-    print("Jai path: %\n", JAI_PATH);
-
     start := current_time_consensus();
 
     files: Table(string, []*Node);

--- a/lexer.jai
+++ b/lexer.jai
@@ -667,7 +667,7 @@ parse_number :: (using iterator: *Iterator, from_dot: bool) -> Token {
     is_valid_numeric_char :: (char: u8, iterator: *Iterator, is_float: *bool) -> bool {
         if is_digit(char) return true;
         if char == #char "_" return true;
-        if !<<is_float && char == #char "." && is_digit(peek(iterator, 2)) {
+        if !<<is_float && char == #char "." {
             <<is_float = true;
             return true;
         }

--- a/parser.jai
+++ b/parser.jai
@@ -1453,7 +1453,9 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
 
     // Notes
     if is_token(parser.lexer, .NOTE) {
-        decl.notes = parse_notes(parser, decl);
+        notes: [..]*Note;
+        parse_notes(parser, decl, *notes);
+        decl.notes = notes;
     }
 
     return decl;
@@ -1472,7 +1474,9 @@ parse_constant_declaration :: (parser: *Parser, ident_token: *Token) -> *Declara
 
     // Notes
     if is_token(parser.lexer, .NOTE) {
-        decl.notes = parse_notes(parser, decl);
+        notes: [..]*Note;
+        parse_notes(parser, decl, *notes);
+        decl.notes = notes;
     }
 
     return decl;
@@ -1490,7 +1494,9 @@ parse_declaration_and_assign :: (parser: *Parser, ident_token: *Token) -> *Decla
 
     // Notes
     if is_token(parser.lexer, .NOTE) {
-        decl.notes = parse_notes(parser, decl);
+        notes: [..]*Note;
+        parse_notes(parser, decl, *notes);
+        decl.notes = notes;
     }
 
     return decl;
@@ -1682,7 +1688,9 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
 
     // Notes
     if is_token(parser.lexer, .NOTE) {
-        proc.notes = parse_notes(parser, proc);
+        notes: [..] * Note;
+        parse_notes(parser, proc, *notes);
+        proc.notes = notes;
     }
 
     return proc;
@@ -1732,6 +1740,12 @@ parse_struct :: (parser: *Parser) -> *Struct {
         parse_struct_directive(parser, _struct);
     }
 
+    notes: [..]*Note;
+
+    if is_token(parser.lexer, .NOTE) {
+        parse_notes(parser, _struct, *notes);
+    }
+
     if is_token(parser.lexer, #char "{") {
         _struct.block = parse_block(parser);
         _struct.block.parent = _struct;
@@ -1750,8 +1764,10 @@ parse_struct :: (parser: *Parser) -> *Struct {
     }
 
     if is_token(parser.lexer, .NOTE) {
-        _struct.notes = parse_notes(parser, _struct);
+        parse_notes(parser, _struct, *notes);
     }
+
+    _struct.notes = notes;
 
     return _struct;
 }
@@ -1779,7 +1795,9 @@ parse_union :: (parser: *Parser) -> *Union {
     }
 
     if is_token(parser.lexer, .NOTE) {
-        _union.notes = parse_notes(parser, _union);
+        notes: [..] *Note;
+        parse_notes(parser, _union, *notes);
+        _union.notes = notes;
     }
 
     return _union;
@@ -1817,7 +1835,9 @@ parse_enum :: (parser: *Parser, is_enum_flags: bool) -> *Enum {
     }
 
     if is_token(parser.lexer, .NOTE) {
-        _enum.notes = parse_notes(parser, _enum);
+        notes: [..] *Note;
+        parse_notes(parser, _enum, *notes);
+        _enum.notes = notes;
     }
 
     return _enum;
@@ -2878,10 +2898,8 @@ parse_inline_assembly :: (parser: *Parser) -> *Inline_Assembly {
     return inline_assembly;
 }
 
-parse_notes :: (parser: *Parser, parent: *Node) -> [] *Note {
-    notes: [..] *Note;
-    while is_token(parser.lexer, .NOTE) array_add(*notes, parse_note(parser, parent));
-    return notes;
+parse_notes :: (parser: *Parser, parent: *Node, notes: *[..]*Note) {
+    while is_token(parser.lexer, .NOTE) array_add(notes, parse_note(parser, parent));
 }
 
 parse_note :: (parser: *Parser, parent: *Node) -> *Note  {


### PR DESCRIPTION
I noticed that notes for structs apparently can come before and after the struct body, so needed to change parse_note to take an [..]*Note instead of returning a [..]*Note to be able to "resume" note parsing. This led to changes at the call sites that I hope you are okay with. The same bug may happen for other things with note I think, if they too are allowed to have them before and after the body, because the current parser does not expect this anywhere, aside from the struct code I fixed. I don't fully know the rules where notes can go in the language, so I didn't add this to any other thing that has notes.