### PR TITLE
DRAFT: Fixes for issue #13

### DIFF
--- a/lexer.jai
+++ b/lexer.jai
@@ -834,14 +834,22 @@ parse_number :: (using iterator: *Iterator, from_dot: bool, has_sign: bool) -> T
         
         if kind != .INT {
             advance(*without_underscores, 2); // Skip 0x, 0h or 0b
+            sign_to_set := ifx kind == .HEX_FLOAT then #char "+" else number_value[0];
             // NOTE: If the number had a sing the skip above won't skip everything we need. For example -0xFF after the skip will become xFF. But because we know that there was a sign in the original string we can replace the 'x' with it so in the end we get: -FF.
             if has_sign {
-                without_underscores[0] = number_value[0];
+                without_underscores[0] = sign_to_set;
             }
         }
         
         // NOTE: We're also parsing HEX_FLOAT here because string_to_float doesn't do that. Because the float is in hex format we can parse it in the same way as an integer and then just treat the bits as a float.
         token.integer_value = string_to_int(without_underscores, base);
+
+        // NOTE: For HEX_FLOAT if it was negative we need to negate the number after parsing because if we pass a negated hex string into string_to_int it changes the bit layout. 
+        // For example -0xFF becomes 0xffffffffffffff01 which is correct for integers but not for our hack with hex floats. For hex floats we want the bits to be the same as the literal so we always parse it as a positive number and negate at the end.
+        sign := number_value[0];
+        if kind == .HEX_FLOAT && has_sign && sign == #char "-" {
+            token.float_value *= -1;
+        }
     }
 
     token.l1 = iterator.line;

--- a/lexer.jai
+++ b/lexer.jai
@@ -229,6 +229,7 @@ is_operator_assignment :: (token: *Token) -> bool {
     if !token return false;
 
     if token.kind == {
+        case #char "=";                          return true;
         case .IS_EQUAL;                          return true;
         case .PIPE_EQUAL;                        return true;
         case .PLUS_EQUAL;                        return true;

--- a/lexer.jai
+++ b/lexer.jai
@@ -539,7 +539,7 @@ parse_note_or_directive :: (using iterator: *Iterator, directive: bool) -> Token
         char := peek(iterator);
         if char == #char "\"" {
             builder: String_Builder;
-            string_token := parse_string(iterator, true);
+            string_token := parse_string(iterator);
             print(*builder, "\"%\"", string_token.string_value);
             token.string_value = builder_to_string(*builder);
         } else {
@@ -628,7 +628,7 @@ parse_identifier :: (using iterator: *Iterator) -> Token {
     return token;
 }
 
-parse_string :: (using iterator: *Iterator, include_escape_slash := false) -> Token {
+parse_string :: (using iterator: *Iterator) -> Token {
     token: Token;
     token.kind = .STRING;
     token.file = iterator.file;
@@ -645,7 +645,7 @@ parse_string :: (using iterator: *Iterator, include_escape_slash := false) -> To
         char := next(iterator);
 
         if escaped {
-            if include_escape_slash then append(*builder, "\\");
+            append(*builder, "\\");
             append(*builder, char);
             escaped = false;
         } else if char == #char "\\" {

--- a/lexer.jai
+++ b/lexer.jai
@@ -415,7 +415,7 @@ parse_next_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
     char := peek(iterator);
 
     // Notes
-    if char == #char "@" && is_identifier_char(peek(iterator, 2)) {
+    if char == #char "@" && (is_identifier_char(peek(iterator, 2)) || peek(iterator, 2) == #char "\"") {
         return parse_note_or_directive(iterator, false);
     }
 
@@ -536,7 +536,15 @@ parse_note_or_directive :: (using iterator: *Iterator, directive: bool) -> Token
     if directive {
         token.string_value = next_while(iterator, char => is_identifier_char(char) || is_digit(char));
     } else {
-        token.string_value = next_while(iterator, char => !is_space(char));
+        char := peek(iterator);
+        if char == #char "\"" {
+            builder: String_Builder;
+            string_token := parse_string(iterator, true);
+            print(*builder, "\"%\"", string_token.string_value);
+            token.string_value = builder_to_string(*builder);
+        } else {
+            token.string_value = next_while(iterator, char => !is_space(char));
+        }
     }
 
     token.l1 = iterator.line;
@@ -620,7 +628,7 @@ parse_identifier :: (using iterator: *Iterator) -> Token {
     return token;
 }
 
-parse_string :: (using iterator: *Iterator) -> Token {
+parse_string :: (using iterator: *Iterator, include_escape_slash := false) -> Token {
     token: Token;
     token.kind = .STRING;
     token.file = iterator.file;
@@ -637,6 +645,7 @@ parse_string :: (using iterator: *Iterator) -> Token {
         char := next(iterator);
 
         if escaped {
+            if include_escape_slash then append(*builder, "\\");
             append(*builder, char);
             escaped = false;
         } else if char == #char "\\" {

--- a/lexer.jai
+++ b/lexer.jai
@@ -1062,9 +1062,11 @@ parse_char_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
     }
 
     if char == #char ":" {
+        // NOTE: For cases like test:   = 5;
+        whitespace := next_while(iterator, is_space);
         // NOTE: For cases like: test :/*comment*/: () {}
         comments_found := eat_comments(iterator, lexer);
-        if comments_found next_char = peek(iterator);
+        if comments_found || whitespace.count > 0 then next_char = peek(iterator);
 
         if next_char == #char "=" {
             next(iterator);

--- a/lexer.jai
+++ b/lexer.jai
@@ -110,8 +110,17 @@ Token :: struct {
     backticked: bool;
 }
 
+Comment_Token :: struct
+{
+    #as using token: Token;
+    token.kind = .COMMENT;
+
+    multiline: bool;
+}
+
 Lexer :: struct {
     tokens: [..]Token;
+    comments: [..]Comment_Token;
     cursor := 0;
     next_backticked: bool;
 }
@@ -369,16 +378,26 @@ is_comment :: (iterator: *Iterator) -> bool {
     return next_char == #char "/" || next_char == #char "*";
 }
 
+eat_comments :: (iterator: *Iterator, lexer: *Lexer) -> bool {
+    comments_found: bool;
+    while is_comment(iterator) {
+        comment := parse_comment(iterator);
+        array_add(*lexer.comments, comment);
+        comments_found = true;
+        next_while(iterator, is_space); // We skip all whitespaces
+    }
+
+    return comments_found;
+}
+
 parse_next_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
     next_while(iterator, is_space); // We skip all whitespaces
 
     // @TODO: remove this
     total_tokens += 1;
 
-    if is_comment(iterator) {
-        parse_comment(iterator); // Skip comments...
-        return .{};
-    }
+    // Skip comments - we don't want them in the parser. But we're keeping a separate list of comments if someone needs them (for example for formatting).
+    eat_comments(iterator, lexer);
 
     char := peek(iterator);
 
@@ -430,12 +449,11 @@ parse_next_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
     }
 
     // Special chars or compound chars
-    return parse_char_token(iterator);
+    return parse_char_token(iterator, lexer);
 }
 
-parse_comment :: (using iterator: *Iterator) -> Token {
-    token: Token;
-    token.kind = .COMMENT;
+parse_comment :: (using iterator: *Iterator) -> Comment_Token {
+    token: Comment_Token;
     token.file = iterator.file;
     token.l0 = iterator.line;
     token.c0 = iterator.column;
@@ -443,9 +461,9 @@ parse_comment :: (using iterator: *Iterator) -> Token {
     // Skip the first //
     next(iterator);
     multiline := next(iterator) == #char "*";
+    token.multiline = multiline;
 
     builder: String_Builder;
-    init_string_builder(*builder);
 
     nested_comment: int;
 
@@ -477,6 +495,10 @@ parse_comment :: (using iterator: *Iterator) -> Token {
     token.string_value = builder_to_string(*builder);
     token.l1 = iterator.line;
     token.c1 = iterator.column;
+
+    if ends_with(token.string_value, "\r") {
+        token.string_value.count -= 1;
+    }
 
     return token;
 }
@@ -617,7 +639,7 @@ parse_here_string :: (using iterator: *Iterator, lexer: *Lexer) {
 
     // #string,cr or #string,\%
     while peek(iterator) == #char "," {
-        comma_token := parse_char_token(iterator);
+        comma_token := parse_char_token(iterator, lexer);
         array_add(*lexer.tokens, comma_token);
 
         if is_identifier_char(peek(iterator)) {
@@ -750,7 +772,7 @@ parse_number :: (using iterator: *Iterator, from_dot: bool) -> Token {
     return token;
 }
 
-parse_char_token :: (iterator: *Iterator) -> Token {
+parse_char_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
     token: Token;
     token.l0 = iterator.line;
     token.file = iterator.file;
@@ -945,6 +967,10 @@ parse_char_token :: (iterator: *Iterator) -> Token {
     }
 
     if char == #char ":" {
+        // NOTE: For cases like: test :/*comment*/: () {}
+        comments_found := eat_comments(iterator, lexer);
+        if comments_found next_char = peek(iterator);
+
         if next_char == #char "=" {
             next(iterator);
             token.kind = .DECLARATION_AND_ASSIGN;

--- a/lexer.jai
+++ b/lexer.jai
@@ -487,7 +487,7 @@ parse_note_or_directive :: (using iterator: *Iterator, directive: bool) -> Token
     token.c0 = iterator.column;
 
     token.kind = ifx directive then Token.Kind.DIRECTIVE else .NOTE;
-    token.string_value = next_while(iterator,  char => is_identifier_char(char) || is_digit(char));
+    token.string_value = next_while(iterator, c => !is_space(c));
 
     token.l1 = iterator.line;
     token.c1 = iterator.column;

--- a/lexer.jai
+++ b/lexer.jai
@@ -101,8 +101,6 @@ Token :: struct {
     l1: int;
     c1: int;
 
-    here_string_cr: bool; // @TODO: Is this good to have this here?
-
     union {
         string_value: string;
         integer_value: int;
@@ -393,7 +391,11 @@ parse_next_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
         directive_token := parse_note_or_directive(iterator, true);
 
         if directive_token.string_value == "string" {
-            return parse_here_string(iterator);
+            array_add(*lexer.tokens, directive_token);
+
+            // NOTE: Here strings are processed in a bit hacky way. parse_here_string adds multiple tokens to the tokens list in lexer. That's why we return an empty token here. 
+            parse_here_string(iterator, lexer);
+            return .{};
         }
 
         return directive_token;
@@ -487,7 +489,11 @@ parse_note_or_directive :: (using iterator: *Iterator, directive: bool) -> Token
     token.c0 = iterator.column;
 
     token.kind = ifx directive then Token.Kind.DIRECTIVE else .NOTE;
-    token.string_value = next_while(iterator, c => !is_space(c));
+    if directive {
+        token.string_value = next_while(iterator, char => is_identifier_char(char) || is_digit(char));
+    } else {
+        token.string_value = next_while(iterator, char => !is_space(char));
+    }
 
     token.l1 = iterator.line;
     token.c1 = iterator.column;
@@ -606,34 +612,50 @@ parse_string :: (using iterator: *Iterator) -> Token {
 }
 
 // @TODO: We need to test it more!
-parse_here_string :: (using iterator: *Iterator) -> Token {
-    token: Token;
-    token.kind = .STRING;
-    token.file = iterator.file;
-    token.l0 = iterator.line;
-    token.c0 = iterator.column;
+parse_here_string :: (using iterator: *Iterator, lexer: *Lexer) {
 
-    // #string,cr
-    if peek(iterator) == #char "," {
-        next(iterator); // eat ,
+    // #string,cr or #string,\%
+    while peek(iterator) == #char "," {
+        comma_token := parse_char_token(iterator);
+        array_add(*lexer.tokens, comma_token);
 
         if is_identifier_char(peek(iterator)) {
-            token.here_string_cr = parse_identifier(iterator).string_value == "cr";
+            identifier := parse_identifier(iterator);
+            print("parsing here string: %\n", identifier.string_value);
+            array_add(*lexer.tokens, identifier);
+        } else if peek(iterator, 1) == #char "\\" && peek(iterator, 2) == #char "%" {
+            token: Token;
+            token.kind = .IDENTIFIER;
+            token.file = iterator.file;
+            token.l0 = iterator.line;
+            token.c0 = iterator.column;
+            token.l1 = token.l0;
+            token.c1 = token.c0;
+            token.string_value = "\\%";
+            array_add(*lexer.tokens, token);
+            next(iterator);
+            next(iterator);
         }
-
     }
 
     next_while(iterator, is_space); // Skip all whitespaces
 
     if !is_identifier_char(peek(iterator)) {
         log_error("Exprected identifier after #string");
-        return .{};
+        return;
     }
 
-    here_identifier := parse_identifier(iterator).string_value;
+    here_identifier_token := parse_identifier(iterator);
+    array_add(*lexer.tokens, here_identifier_token);
+    here_identifier := here_identifier_token.string_value;
+
+    string_token: Token;
+    string_token.kind = .STRING;
+    string_token.file = iterator.file;
+    string_token.l0 = iterator.line;
+    string_token.c0 = iterator.column;
 
     builder: String_Builder;
-    init_string_builder(*builder);
 
     while true {
         char := next(iterator);
@@ -661,11 +683,11 @@ parse_here_string :: (using iterator: *Iterator) -> Token {
         append(*builder, char);
     }
 
-    token.l1 = iterator.line;
-    token.c1 = iterator.column;
-    token.string_value = builder_to_string(*builder);
+    string_token.l1 = iterator.line;
+    string_token.c1 = iterator.column;
+    string_token.string_value = builder_to_string(*builder);
 
-    return token;
+    array_add(*lexer.tokens, string_token);
 }
 
 parse_number :: (using iterator: *Iterator, from_dot: bool) -> Token {

--- a/lexer.jai
+++ b/lexer.jai
@@ -101,13 +101,25 @@ Token :: struct {
     l1: int;
     c1: int;
 
+    // NOTE: string_value is separated from int and float value because for numbers we want to keep both representations - string represantation of a number is usefull for example in formatting to not remove underscores from literals.
+    string_value: string;
+    number_kind: Number_Kind;
     union {
-        string_value: string;
         integer_value: int;
-        float_value: float;
+        float_value: float64;
     }
 
     backticked: bool;
+}
+
+Number_Kind :: enum {
+    UNKNOWN;
+    INT;
+    FLOAT;
+    SCIENTIFIC_FLOAT;
+    HEX_INT;
+    HEX_FLOAT;
+    BINARY;
 }
 
 Comment_Token :: struct
@@ -160,7 +172,8 @@ print_token :: (token: *Token) {
     }
 
     if token.kind == .NUMBER {
-        if token.float_value > 0 {
+        kind := token.number_kind;
+        if kind == .FLOAT || kind == .SCIENTIFIC_FLOAT || kind == .HEX_FLOAT {
             value = tprint("%", token.float_value);
         } else {
             value = tprint("%", token.integer_value);
@@ -431,14 +444,22 @@ parse_next_token :: (iterator: *Iterator, lexer: *Lexer) -> Token {
         return parse_string(iterator);
     }
 
+    has_sign: bool;
+    previous_token := ifx lexer.tokens then lexer.tokens[lexer.tokens.count - 1] else .{};
+    if (is_operator(*previous_token) || previous_token.kind == .DECLARATION_AND_ASSIGN) &&
+       (char == #char "+" || char == #char "-") {
+        has_sign = true;
+        char = peek(iterator, 2);
+    }
+
     // .40
     if char == #char "." && is_digit(peek(iterator, 2)) {
-        return parse_number(iterator, true);
+        return parse_number(iterator, true, has_sign);
     }
 
     // Numbers
     if is_digit(char) {
-        return parse_number(iterator, false);
+        return parse_number(iterator, false, has_sign);
     }
 
     // Backtick
@@ -713,58 +734,115 @@ parse_here_string :: (using iterator: *Iterator, lexer: *Lexer) {
     array_add(*lexer.tokens, string_token);
 }
 
-parse_number :: (using iterator: *Iterator, from_dot: bool) -> Token {
+parse_number :: (using iterator: *Iterator, from_dot: bool, has_sign: bool) -> Token {
     token: Token;
     token.l0 = iterator.line;
     token.file = iterator.file;
     token.c0 = iterator.column;
     token.kind = .NUMBER;
 
-    hex := false;
-    if !from_dot && peek(iterator) == #char "0" && peek(iterator, 2) == #char "x" {
-        next(iterator); // eat 0
-        next(iterator); // eat x
-        hex = true;
-    }
+    kind: Number_Kind = .UNKNOWN;
 
     builder: String_Builder;
-    init_string_builder(*builder);
+
+    if has_sign {
+        append(*builder, next(iterator)); // skip the sign
+    }
 
     if from_dot {
-        next(iterator); // eat .
-        append(*builder, "0.");
+        kind = .FLOAT;
+        append(*builder, next(iterator)); // eat .
     }
 
-    if hex append(*builder, "0x");
-
-    is_float := from_dot;
-
-    is_valid_numeric_char :: (char: u8, iterator: *Iterator, is_float: *bool) -> bool {
-        if is_digit(char) return true;
-        if char == #char "_" return true;
-        if !<<is_float && char == #char "." && peek(iterator, 2) != #char "." {
-            <<is_float = true;
-            return true;
+    if !from_dot && peek(iterator) == #char "0" {
+        next_char := peek(iterator, 2);
+        if next_char == {
+            case #char "x"; kind = .HEX_INT;
+            case #char "h"; kind = .HEX_FLOAT;
+            case #char "b"; kind = .BINARY;
         }
 
-        return false;
+        if kind != .UNKNOWN {
+            append(*builder, next(iterator)); // eat 0
+            append(*builder, next(iterator)); // eat x, h or b
+        }
     }
 
-    // @TOOD: clean this up!
-    if hex {
-        while !end(iterator) && (is_digit(peek(iterator)) || is_identifier_char(peek(iterator))) {
+    if kind == .UNKNOWN {
+        // NOTE: It could be int, float or scientific float. Now we assume int because float type will be decided after we parse the integer part.
+        kind = .INT;
+    }
+
+    is_hex_char :: (char: u8) -> bool {
+        return (char >= #char "a" && char <= #char "f") ||
+               (char >= #char "A" && char <= #char "F");
+    }
+
+    is_underscore :: (char: u8) -> bool { return char == #char "_"; }
+
+    int_predicate :: (char) => is_digit(char) || is_underscore(char);
+    hex_predicate :: (char) => is_digit(char) || is_hex_char(char) || is_underscore(char);
+    binary_predicate :: (char) => char == #char "1" || char == #char "0" || is_underscore(char);
+
+    value: string;
+    if kind == {
+        case .INT; 
+            value = next_while(iterator, int_predicate);
+        case .HEX_INT; #through;
+        case .HEX_FLOAT;
+            value = next_while(iterator, hex_predicate);
+        case .BINARY;
+            value = next_while(iterator, binary_predicate);
+    }
+
+    append(*builder, value);
+
+    if from_dot || (peek(iterator, 1) == #char "." && peek(iterator, 2) != #char ".") {
+        kind = .FLOAT;
+        if !from_dot append(*builder, next(iterator)); // eat '.' if it wasn'y already eaten at the beginning
+
+        decimal_part := next_while(iterator, int_predicate);
+        append(*builder, decimal_part);
+
+        if peek(iterator) == #char "e" {
+            kind = .SCIENTIFIC_FLOAT;
             append(*builder, next(iterator));
-        }
-    } else {
-        while !end(iterator) && is_valid_numeric_char(peek(iterator), iterator, *is_float) {
-            append(*builder, next(iterator));
+            sign := peek(iterator);
+            if sign == #char "+" || sign == #char "-" {
+                append(*builder, next(iterator));
+            }
+
+            exponent_part := next_while(iterator, int_predicate);
+            append(*builder, exponent_part);
         }
     }
 
     number_value := builder_to_string(*builder);
-    number_value = replace(number_value, "_", ""); // Remove all _ in number
-
     token.string_value = number_value;
+    token.number_kind = kind;
+
+    without_underscores := replace(number_value, "_", ""); // Remove all _ in number
+    if kind == .FLOAT || kind == .SCIENTIFIC_FLOAT {
+        token.float_value = string_to_float(without_underscores);
+    } else {
+        base := 10;
+        if kind == {
+            case .HEX_FLOAT; #through;
+            case .HEX_INT; base = 16;
+            case .BINARY; base = 2;
+        }
+        
+        if kind != .INT {
+            advance(*without_underscores, 2); // Skip 0x, 0h or 0b
+            // NOTE: If the number had a sing the skip above won't skip everything we need. For example -0xFF after the skip will become xFF. But because we know that there was a sign in the original string we can replace the 'x' with it so in the end we get: -FF.
+            if has_sign {
+                without_underscores[0] = number_value[0];
+            }
+        }
+        
+        // NOTE: We're also parsing HEX_FLOAT here because string_to_float doesn't do that. Because the float is in hex format we can parse it in the same way as an integer and then just treat the bits as a float.
+        token.integer_value = string_to_int(without_underscores, base);
+    }
 
     token.l1 = iterator.line;
     token.c1 = iterator.column;

--- a/lexer.jai
+++ b/lexer.jai
@@ -733,6 +733,7 @@ parse_char_token :: (iterator: *Iterator) -> Token {
     token.file = iterator.file;
     token.c0 = iterator.column;
 
+    char_start := iterator.buffer.data;
     char := next(iterator);
     next_char := peek(iterator);
 
@@ -935,6 +936,10 @@ parse_char_token :: (iterator: *Iterator) -> Token {
     if token.kind == .UNKNOWN {
         token.kind = xx char;
     }
+
+    char_end := iterator.buffer.data;
+    token.string_value.data = char_start;
+    token.string_value.count = char_end - char_start;
 
     token.l1 = iterator.line;
     token.c1 = iterator.column;

--- a/parser.jai
+++ b/parser.jai
@@ -650,7 +650,6 @@ Unary_Operation :: struct {
         DOT;
         POINTER;
         POINTER_DEREFERENCE;
-        EXPAND;
         ELLIPSIS;
         BITWISE_NOT;
     }

--- a/parser.jai
+++ b/parser.jai
@@ -80,6 +80,7 @@ Node :: struct {
         DIRECTIVE_DISCARD;
         DIRECTIVE_EXISTS;
         DIRECTIVE_CONTEXT;
+        DIRECTIVE_STRING;
 
         NOTE;
     }
@@ -430,6 +431,16 @@ Directive_Context :: struct {
     kind = .DIRECTIVE_CONTEXT;
 }
 
+Directive_String :: struct {
+    using #as node: Node;
+    kind = .DIRECTIVE_STRING;
+
+    cr: bool;
+    escape_percent: bool;
+    identifier: string;
+    string_value: string;
+}
+
 Literal :: struct {
     using #as node: Node;
     kind = .LITERAL;
@@ -445,7 +456,6 @@ Literal :: struct {
     }
 
     value_type: Value_Type;
-    here_string_cr: bool;
 
     using values: union {
         _string:  string;
@@ -2109,6 +2119,7 @@ parse_directive :: (parser: *Parser) -> *Node {
         case "Context";             return parse_directive_context(parser);
         case "compile_time";        return parse_directive_compile_time(parser);
         case "discard";             return parse_directive_discard(parser);
+        case "string";              return parse_directive_string(parser);
 
         case "library";             return parse_directive_library(parser, false);
         case "system_library";      return parse_directive_library(parser, true);
@@ -2129,6 +2140,38 @@ parse_directive :: (parser: *Parser) -> *Node {
     log_error("Unknown directive #% (%:%:%)!", directive_token.string_value, directive_token.file, directive_token.l0, directive_token.c0);
 
     return null;
+}
+
+parse_directive_string :: (parser: *Parser) -> *Directive_String {
+    directive_string := New(Directive_String);
+
+    while maybe_eat_token(parser.lexer, #char ",") {
+        if maybe_eat_token(parser.lexer, token => token.kind == .IDENTIFIER && token.string_value == "cr") {
+            print("found cr\n");
+            directive_string.cr = true;
+        }
+
+        if maybe_eat_token(parser.lexer, token => token.kind == .IDENTIFIER && token.string_value == "\\%") {
+            directive_string.escape_percent = true;
+            print("found \\\%\n");
+        }
+    }
+
+    identifier := eat_token(parser.lexer, .IDENTIFIER);
+    if !identifier {
+        log_error("Exprected identifier after #string");
+        return null;
+    }
+    directive_string.identifier = identifier.string_value;
+    
+    value := eat_token(parser.lexer, .STRING);
+    if !value {
+        log_error("Expected string token after here string indentifier");
+        return null;
+    }
+    directive_string.string_value = value.string_value;
+
+    return directive_string;
 }
 
 parse_directive_run :: (parser: *Parser) -> *Directive_Run {
@@ -2600,7 +2643,6 @@ parse_literal :: (parser: *Parser) -> *Node {
     if base_literal.kind == {
         case .STRING;
             literal.value_type = .STRING;
-            literal.here_string_cr = base_literal.here_string_cr;
             literal._string = base_literal.string_value;
         case .KEYWORD_TRUE;
             literal.value_type = .BOOL;

--- a/parser.jai
+++ b/parser.jai
@@ -3009,6 +3009,8 @@ parse_using :: (parser: *Parser) -> *Node {
              _using.filter_type = .EXCEPT;
             case "only";
              _using.filter_type = .ONLY;
+            case "no_parameters";
+             _using.no_parameters = true;
         }
     }
 

--- a/parser.jai
+++ b/parser.jai
@@ -35,7 +35,7 @@ Node :: struct {
         DEFER;
         USING;
         CAST;
-        COMMA_SEPERATED_EXPRESSION;
+        COMMA_SEPARATED_EXPRESSION;
         IF;
         CASE;
         BREAK;
@@ -135,7 +135,7 @@ Compound_Declaration_Item :: struct {
 
     Item_Kind :: enum {
         DECLARATION;
-        ASSING;
+        ASSIGN;
     }
 
     item_kind: Item_Kind;
@@ -494,7 +494,7 @@ _Operator :: enum u8 {
     MODULO; // %
     LESS; // >
     GREATER; // <
-    ASSING; // =
+    ASSIGN; // =
     BITWISE_AND; // &
     PIPE; // |
     BITWISE_NOT; // ~
@@ -565,7 +565,7 @@ convert_operator_to_level :: (op: _Operator) -> u8 {
         case .LOGICAL_AND; return 6;
         case .LOGICAL_OR; return 5;
 
-        case .ASSING;
+        case .ASSIGN;
         case .BITWISE_AND_ASSIGNMENT;
         case .BITWISE_XOR_ASSIGNMENT;
         case .PIPE_EQUAL;
@@ -669,9 +669,9 @@ Unary_Operation :: struct {
     expression: *Node;
 }
 
-Comma_Seperated_Expression :: struct {
+Comma_Separated_Expression :: struct {
     using #as node: Node;
-    kind = .COMMA_SEPERATED_EXPRESSION;
+    kind = .COMMA_SEPARATED_EXPRESSION;
 
     members: []*Node;
 }
@@ -996,7 +996,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
         init(*nodes_types);
 
         if maybe_eat_token(parser.lexer, #char "=") {
-            table_add(*nodes_types, 0, .ASSING);
+            table_add(*nodes_types, 0, .ASSIGN);
         } else if maybe_eat_token(parser.lexer, #char ":") {
             table_add(*nodes_types, 0, .DECLARATION);
         }
@@ -1035,7 +1035,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
                 if is_operator_assignment(peek_token(lexer, peek)) return true;
                 if is_token(lexer, #char ":", peek) return true;
                 if is_token(lexer, #char ";", peek) return true;
-                if is_token(lexer, #char ")", peek) return true; // @TODO: maybe check for this only if we open the comma_seperated_expression with the ( ...
+                if is_token(lexer, #char ")", peek) return true; // @TODO: maybe check for this only if we open the comma_separated_expression with the ( ...
                 if is_token(lexer, .DECLARATION_AND_ASSIGN, peek) return true;
 
                 return false;
@@ -1064,7 +1064,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
 
                 if is_token(parser.lexer, #char ",", 1) || is_end(parser.lexer, 1) {
                     eat_token(parser.lexer, #char "=");
-                    table_add(*nodes_types, item_index, .ASSING);
+                    table_add(*nodes_types, item_index, .ASSIGN);
                 } else {
                     break;
                 }
@@ -1108,11 +1108,25 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
             }
         }
 
+        
         // Compound Declaration
-        if maybe_eat_token(parser.lexer, #char ":") {
+        is_compound_declaration: bool;
+        default_compound_declaration_item_kind: Compound_Declaration_Item.Item_Kind;
+        if maybe_eat_token(parser.lexer, #char ":") || maybe_eat_token(parser.lexer, .DECLARATION_AND_ASSIGN) {
+            // NOTE: If the expression ends with : or := it doesn't matter what was before, we want to treat the expression as compound declaration.
+            is_compound_declaration = true;
+            default_compound_declaration_item_kind = .DECLARATION;
+        } else if is_token(parser.lexer, #char "=") {
+            // NOTE: If the expression ends with = we only want to treat it as compound declaration if any of the previous elements had a :. For example a: b = 1, 2;
+            is_compound_declaration = nodes_types.count > 0;
+            if is_compound_declaration eat_token(parser.lexer, #char "=");
+            default_compound_declaration_item_kind = .ASSIGN;
+        }
+
+        if is_compound_declaration {
             compound_declaration := New(Compound_Declaration);
 
-            transform_nodes_into_items(compound_declaration, nodes_types, nodes, .DECLARATION);
+            transform_nodes_into_items(compound_declaration, nodes_types, nodes, default_compound_declaration_item_kind);
 
             compound_declaration.members = nodes;
             compound_declaration.parent = parent;
@@ -1125,38 +1139,16 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
             return compound_declaration;
         }
 
-        // Compound Declaration & Assing
-        if maybe_eat_token(parser.lexer, .DECLARATION_AND_ASSIGN) {
-            compound_declaration := New(Compound_Declaration);
+        comma_separated_expression := New(Comma_Separated_Expression);
 
-            transform_nodes_into_items(compound_declaration, nodes_types, nodes, .DECLARATION);
-
-            compound_declaration.members = nodes;
-            compound_declaration.parent = parent;
-            compound_declaration.expression = parse(parser, compound_declaration);
-
-            set_start_location(compound_declaration, base_node);
-            set_end_location(compound_declaration, peek_token(parser.lexer, -1));
-            parser.node_visit(compound_declaration, parser.user_data);
-
-            return compound_declaration;
-        }
-
-        comma_seperated_expression := New(Comma_Seperated_Expression);
-
-        if is_token(parser.lexer, #char "=") {
-            transform_nodes_into_items(comma_seperated_expression, nodes_types, nodes, .ASSING);
-        } else {
-            for nodes it.parent = comma_seperated_expression;
-        }
-
-        comma_seperated_expression.members = nodes;
+        for nodes it.parent = comma_separated_expression;
+        comma_separated_expression.members = nodes;
 
         if is_operator_assignment(peek_token(parser.lexer)) {
             binary_operation := New(Binary_Operation);
 
             binary_operation.parent = parent;
-            binary_operation.left = comma_seperated_expression;
+            binary_operation.left = comma_separated_expression;
             binary_operation.operation = create_operator_from_token(eat_token(parser.lexer));
             binary_operation.right = parse(parser, null);
 
@@ -1175,13 +1167,13 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
             return binary_operation;
         }
 
-        comma_seperated_expression.parent = parent;
+        comma_separated_expression.parent = parent;
 
-        set_start_location(comma_seperated_expression, base_node);
-        set_end_location(comma_seperated_expression, peek_token(parser.lexer, -1));
-        parser.node_visit(comma_seperated_expression, parser.user_data);
+        set_start_location(comma_separated_expression, base_node);
+        set_end_location(comma_separated_expression, peek_token(parser.lexer, -1));
+        parser.node_visit(comma_separated_expression, parser.user_data);
 
-        return comma_seperated_expression;
+        return comma_separated_expression;
     }
 
     parser.node_visit(base_node, parser.user_data);
@@ -1291,7 +1283,7 @@ create_operator_from_token :: (using token: Token) -> _Operator {
         case #char "*";                           return .MULTIPLICATION;
         case #char "/";                           return .DIVISION;
         case #char "%";                           return .MODULO;
-        case #char "=";                           return .ASSING;
+        case #char "=";                           return .ASSIGN;
         case #char ".";                           return .DOT;
         case #char "&";                           return .BITWISE_AND;
         case #char "|";                           return .PIPE;
@@ -1734,23 +1726,23 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
             return parse_quick_lambda(parser, members);
         }
 
-        // Comma Seperated Expression @TODO: maybe move this somewhere else?
-        comma_seperated_expression := New(Comma_Seperated_Expression);
+        // Comma Separated Expression @TODO: maybe move this somewhere else?
+        comma_separated_expression := New(Comma_Separated_Expression);
 
-        comma_seperated_expression.members = members;
-        for comma_seperated_expression.members it.parent = comma_seperated_expression;
+        comma_separated_expression.members = members;
+        for comma_separated_expression.members it.parent = comma_separated_expression;
 
         // Binary operation eg: ((10+10) - (20+5))
         if is_operator(peek_token(parser.lexer)) {
-            return parse_binary_operation(parser, comma_seperated_expression);
+            return parse_binary_operation(parser, comma_separated_expression);
         }
 
-        // Array Subscript after Comma Seperated Expression eg: *(<<arr)[it]
+        // Array Subscript after Comma Separated Expression eg: *(<<arr)[it]
         if is_token(parser.lexer, #char "[") {
-            return parse_array_subscript(parser, comma_seperated_expression);
+            return parse_array_subscript(parser, comma_separated_expression);
         }
 
-        return comma_seperated_expression;
+        return comma_separated_expression;
     }
 
     proc := New(Procedure);

--- a/parser.jai
+++ b/parser.jai
@@ -236,6 +236,7 @@ For :: struct {
     using #as node: Node;
     kind = .FOR;
 
+    is_v2: bool;
     by_pointer: bool;
     reversed: bool;
     no_abc: bool; // #no_abc
@@ -2870,6 +2871,7 @@ parse_for :: (parser: *Parser) -> *Node {
     token := peek_token(parser.lexer);
     if token.kind == .DIRECTIVE && token.string_value == "v2" {
         eat_token(parser.lexer, .DIRECTIVE);
+        _for.is_v2 = true;
     }
 
     if maybe_eat_token(parser.lexer, #char "<") {

--- a/parser.jai
+++ b/parser.jai
@@ -373,6 +373,7 @@ If :: struct {
     condition: *Node;
     if_kind: If_Kind;
     marked_as_complete: bool;
+    then_keyword_used: bool;
     _then: *Node;
     _else: *Node;
 }
@@ -2961,8 +2962,15 @@ parse_if :: (parser: *Parser, kind: If.If_Kind = .UNKNOWN, compile_time := false
             _if.no_aoc = true;
         }
 
-        maybe_eat_token(parser.lexer, .KEYWORD_THEN);
-        _if._then = parse(parser, _if);
+        then_found, then_token := maybe_eat_token(parser.lexer, .KEYWORD_THEN);
+        _if.then_keyword_used = then_found;
+        // NOTE: In ifx we only want to parse _then if the 'then' keyword was actually used. For ifx with implicit 'then' _then will be empty because the condition is also treated as _then.
+        if _if.if_kind == .IF || (_if.if_kind == .IFX && then_found) {
+            _if._then = parse(parser, _if);
+        }
+
+        // NOTE: In ifs without blocks statements need the semicolon. For example: if true then print("true"); else print("false");
+        maybe_eat_token(parser.lexer, #char ";");
 
         if maybe_eat_token(parser.lexer, .KEYWORD_ELSE) {
             _if._else = parse(parser, _if);

--- a/parser.jai
+++ b/parser.jai
@@ -1764,6 +1764,8 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
         // Comma Separated Expression @TODO: maybe move this somewhere else?
         comma_separated_expression := New(Comma_Separated_Expression);
         comma_separated_expression.surrounded_with_parens = true;
+        comma_separated_expression.location = header_location;
+        set_end_location(*comma_separated_expression.location, peek_token(parser.lexer, -1));
 
         comma_separated_expression.members = members;
         for comma_separated_expression.members it.parent = comma_separated_expression;

--- a/parser.jai
+++ b/parser.jai
@@ -250,6 +250,8 @@ For :: struct {
     index: *Node;
     iterator: *Node;
     body: *Node;
+    by_pointer_condition: *Node;
+    reversed_condition: *Node;
 }
 
 Procedure :: struct {
@@ -2963,14 +2965,28 @@ parse_for :: (parser: *Parser) -> *Node {
         _for.is_v2 = true;
     }
 
-    if maybe_eat_token(parser.lexer, #char "<") {
-        _for.reversed = true;
-        _for.by_pointer = maybe_eat_token(parser.lexer, #char "*");
-    }
-
-    if maybe_eat_token(parser.lexer, #char "*") {
-        _for.by_pointer = true;
-        _for.reversed = maybe_eat_token(parser.lexer, #char "<");
+    modifier_found := true;
+    while modifier_found {
+        // TODO: Handle multiple modifiers of the same type and report errors if there are any.
+        token := peek_token(parser.lexer);
+        if token.kind == {
+            case #char "<";
+                eat_token(parser.lexer);
+                _for.reversed = true;
+            case #char "*";
+                eat_token(parser.lexer);
+                _for.by_pointer = true;
+            case .TIMES_EQUAL;
+                eat_token(parser.lexer);
+                _for.by_pointer_condition = parse(parser, _for);
+                maybe_eat_token(parser.lexer, #char ",");
+            case .LESS_EQUAL;
+                eat_token(parser.lexer);
+                _for.reversed_condition = parse(parser, _for);
+                maybe_eat_token(parser.lexer, #char ",");
+            case;
+                modifier_found = false;
+        }
     }
 
     // Only iterator

--- a/parser.jai
+++ b/parser.jai
@@ -3,6 +3,7 @@ Parser :: struct(User_Data_Type: Type) {
     node_visit: (node: *Node, user_data: User_Data_Type);
     user_data: User_Data_Type;
     inside_proc_args: bool;
+    inside_compound_declaration: bool;
 }
 
 Node :: struct {
@@ -123,10 +124,10 @@ Compound_Declaration :: struct {
     using #as node: Node;
     kind = .COMPOUND_DECLARATION;
 
+    const: bool;
     members: [] *Node;
 
-    type_inst: *Node;
-    expression: *Node;
+    type_inst: *Declaration;
 }
 
 Compound_Declaration_Item :: struct {
@@ -972,6 +973,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
     can_contain_comma_separated_expression :: (kind: Node.Kind) -> bool {
         if kind == .BLOCK return true;
         if kind == .COMPOUND_DECLARATION return true;
+        if kind == .DECLARATION return true;
         // if kind == .STRUCT return true;
         // if kind == .ENUM return true;
         // if kind == .UNION return true;
@@ -1038,6 +1040,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
                 if is_token(lexer, #char ";", peek) return true;
                 if is_token(lexer, #char ")", peek) return true; // @TODO: maybe check for this only if we open the comma_separated_expression with the ( ...
                 if is_token(lexer, .DECLARATION_AND_ASSIGN, peek) return true;
+                if is_token(lexer, .CONSTANT_DECLARATION, peek) return true;
 
                 return false;
             }
@@ -1112,8 +1115,12 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
         
         // Compound Declaration
         is_compound_declaration: bool;
+        final_token := peek_token(parser.lexer);
         default_compound_declaration_item_kind: Compound_Declaration_Item.Item_Kind;
-        if maybe_eat_token(parser.lexer, #char ":") || maybe_eat_token(parser.lexer, .DECLARATION_AND_ASSIGN) {
+        // NOTE: Don't eat : or := because parse_type_instantiation and parse_declaration_and_assign will do that
+        if maybe_eat_token(parser.lexer, #char ":") || 
+           maybe_eat_token(parser.lexer, .DECLARATION_AND_ASSIGN) ||
+           maybe_eat_token(parser.lexer, .CONSTANT_DECLARATION) {
             // NOTE: If the expression ends with : or := it doesn't matter what was before, we want to treat the expression as compound declaration.
             is_compound_declaration = true;
             default_compound_declaration_item_kind = .DECLARATION;
@@ -1126,17 +1133,29 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
 
         if is_compound_declaration {
             compound_declaration := New(Compound_Declaration);
+            parser.inside_compound_declaration = true;
 
             transform_nodes_into_items(compound_declaration, nodes_types, nodes, default_compound_declaration_item_kind);
 
             compound_declaration.members = nodes;
             compound_declaration.parent = parent;
-            compound_declaration.type_inst = parse(parser, compound_declaration);
+            if final_token.kind == {
+                case #char ":";
+                    compound_declaration.type_inst = parse_type_instantiation(parser, null, true);
+                    compound_declaration.const = compound_declaration.type_inst.const;
+                case .DECLARATION_AND_ASSIGN; #through;
+                case #char "=";
+                    compound_declaration.type_inst = parse_declaration_and_assign(parser, null, true);
+                case .CONSTANT_DECLARATION;
+                    compound_declaration.type_inst = parse_constant_declaration(parser, null, true);
+                    compound_declaration.const = true;
+            }
 
             set_start_location(compound_declaration, base_node);
             set_end_location(compound_declaration, peek_token(parser.lexer, -1));
             parser.node_visit(compound_declaration, parser.user_data);
 
+            parser.inside_compound_declaration = false;
             return compound_declaration;
         }
 
@@ -1342,7 +1361,7 @@ parse_node :: (parser: *Parser, parent: *Node) -> *Node {
         }
 
         // Binary operation
-        if is_operator(peek_token(parser.lexer)) && (!is_token(parser.lexer, #char "=") || !is_token(parser.lexer, #char ",", 1)) {
+        if is_operator(peek_token(parser.lexer)) && !is_token(parser.lexer, #char "=") && !parser.inside_compound_declaration {
             return parse_binary_operation(parser, parse_identifier(parser, ident));
         }
 
@@ -1370,7 +1389,7 @@ parse_node :: (parser: *Parser, parent: *Node) -> *Node {
             return parse_declaration_and_assign(parser, ident);
         }
 
-        if is_token(parser.lexer, #char ":") && !is_token(parser.lexer, #char ",", 1) {
+        if is_token(parser.lexer, #char ":") && !is_token(parser.lexer, #char ",", 1) && !parser.inside_compound_declaration {
             return parse_type_instantiation(parser, ident);
         }
 
@@ -1556,10 +1575,13 @@ parse_comment :: (parser: *Parser) -> *Comment {
 
 // player: Entity;
 // player: Entity = .{health=20};
-parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declaration {
-    eat_token(parser.lexer, #char ":");
+parse_type_instantiation :: (parser: *Parser, ident_token: *Token, first_operator_eaten := false) -> *Declaration {
+    if !first_operator_eaten eat_token(parser.lexer, #char ":");
     decl := New(Declaration);
-    decl.name = ident_token.string_value;
+    if ident_token {
+        decl.name = ident_token.string_value;
+        decl.backticked = ident_token.backticked;
+    }
 
     if is_token(parser.lexer, #char "(") {
         decl.type_inst = parse_procedure(parser, true);
@@ -1573,16 +1595,16 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
         decl.type_inst = parse(parser, decl);
     }
 
-    decl.backticked = ident_token.backticked;
-
     // decl: u8 #align 32
     if maybe_eat_token(parser.lexer, t => t.kind == .DIRECTIVE && t.string_value == "align") {
         align_token := eat_token(parser.lexer, .NUMBER);
         decl.alignment = parse_int(*align_token.string_value);
     }
 
-    // decl: type_inst = exp;
-    if maybe_eat_token(parser.lexer, #char "=") {
+    is_const := is_token(parser.lexer, #char ":");
+    // decl: type_inst = exp; or decl: type_inst : exp;
+    if maybe_eat_token(parser.lexer, #char "=") || maybe_eat_token(parser.lexer, #char ":") {
+        decl.const = is_const;
         decl.expression = parse(parser, decl);
     }
 
@@ -1611,11 +1633,13 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
 }
 
 // PLAYER_MAX_HP :: 120;
-parse_constant_declaration :: (parser: *Parser, ident_token: *Token) -> *Declaration {
-    eat_token(parser.lexer, .CONSTANT_DECLARATION);
+parse_constant_declaration :: (parser: *Parser, ident_token: *Token, first_operator_eaten := false) -> *Declaration {
+    if !first_operator_eaten eat_token(parser.lexer, .CONSTANT_DECLARATION);
     decl := New(Declaration);
-    decl.name = ident_token.string_value;
-    decl.backticked = ident_token.backticked;
+    if ident_token {
+        decl.name = ident_token.string_value;
+        decl.backticked = ident_token.backticked;
+    }
     decl.const = true;
     decl.expression = parse(parser, decl);
 
@@ -1631,12 +1655,16 @@ parse_constant_declaration :: (parser: *Parser, ident_token: *Token) -> *Declara
     return decl;
 }
 
+a, b : int : 1, 2;
+
 // player_position := Vec3.{10, 20, 10};
-parse_declaration_and_assign :: (parser: *Parser, ident_token: *Token) -> *Declaration {
-    eat_token(parser.lexer, .DECLARATION_AND_ASSIGN);
+parse_declaration_and_assign :: (parser: *Parser, ident_token: *Token, first_operator_eaten := false) -> *Declaration {
+    if !first_operator_eaten eat_token(parser.lexer, .DECLARATION_AND_ASSIGN);
     decl := New(Declaration);
-    decl.name = ident_token.string_value;
-    decl.backticked = ident_token.backticked;
+    if ident_token {
+        decl.name = ident_token.string_value;
+        decl.backticked = ident_token.backticked;
+    }
     decl.expression = parse(parser, decl);
 
     maybe_eat_token(parser.lexer, #char ";");
@@ -2141,13 +2169,11 @@ parse_directive_string :: (parser: *Parser) -> *Directive_String {
 
     while maybe_eat_token(parser.lexer, #char ",") {
         if maybe_eat_token(parser.lexer, token => token.kind == .IDENTIFIER && token.string_value == "cr") {
-            print("found cr\n");
             directive_string.cr = true;
         }
 
         if maybe_eat_token(parser.lexer, token => token.kind == .IDENTIFIER && token.string_value == "\\%") {
             directive_string.escape_percent = true;
-            print("found \\\%\n");
         }
     }
 

--- a/parser.jai
+++ b/parser.jai
@@ -3035,7 +3035,7 @@ parse_if :: (parser: *Parser, kind: If.If_Kind = .UNKNOWN, compile_time := false
     if _if.condition && _if.condition.kind == .BINARY_OPERATION {
         binary_op := find_last_binary_operator(xx _if.condition);
 
-        switch = binary_op.operation == .IS_EQUAL && binary_op.right && binary_op.right.kind == .BLOCK;
+        switch = binary_op.operation == .IS_EQUAL && binary_op.right == null;
     }
 
     if !switch {

--- a/parser.jai
+++ b/parser.jai
@@ -198,6 +198,7 @@ Cast :: struct {
 
     auto: bool;
     function_style: bool;
+    postfix: bool;
 
     expression: *Node;
     cast_expression: *Node;
@@ -2796,6 +2797,8 @@ parse_binary_operation :: (parser: *Parser, left: *Node) -> *Node {
     //     return parse_array_or_struct_literal(parser, left);
     // }
 
+    initial_left_parent := left.parent;
+
     binary_operation := New(Binary_Operation);
     binary_operation.left = left;
     binary_operation.left.parent = binary_operation;
@@ -2827,6 +2830,14 @@ parse_binary_operation :: (parser: *Parser, left: *Node) -> *Node {
         }
 
         return unary_operation;
+    }
+
+    // NOTE: Postfix cast: a.(*int)
+    if binary_operation.operation == .DOT && is_token(parser.lexer, #char "(") {
+        free(binary_operation);
+        _cast := parse_cast(parser, false, left);
+        _cast.parent = initial_left_parent;
+        return _cast;
     }
 
     // Guard?
@@ -3086,12 +3097,8 @@ parse_using :: (parser: *Parser) -> *Node {
     return _using;
 }
 
-parse_cast :: (parser: *Parser, auto: bool = false) -> *Cast {
-    _cast := New(Cast);
-    _cast.auto = auto;
-
-    eat_token(parser.lexer, ifx auto then Token.Kind.KEYWORD_AUTO_CAST else Token.Kind.KEYWORD_CAST);
-
+// NOTE: The expression is only set if we're parsing a postfix cast
+parse_cast :: (parser: *Parser, auto: bool = false, expression: *Node = null) -> *Node {
     parse_modifier :: () #expand {
         eat_token(parser.lexer, #char ",");
 
@@ -3107,31 +3114,51 @@ parse_cast :: (parser: *Parser, auto: bool = false) -> *Cast {
         }
     }
 
-    // modifiers
-    while is_token(parser.lexer, #char ",") {
-        parse_modifier();
+    _cast := New(Cast);
+    _cast.auto = auto;
+
+    if !expression {
+        eat_token(parser.lexer, ifx auto then Token.Kind.KEYWORD_AUTO_CAST else Token.Kind.KEYWORD_CAST);
+
+        // modifiers
+        while is_token(parser.lexer, #char ",") {
+            parse_modifier();
+        }
+    } else {
+        expression.parent = _cast;
+        _cast.expression = expression;
+        _cast.postfix = true;
     }
 
     if !auto && maybe_eat_token(parser.lexer, #char "(") {
         _cast.cast_expression = parse(parser, _cast);
 
-        if maybe_eat_token(parser.lexer, #char ",") {
-            _cast.function_style = true; // New cast is function like `cast(type, expression)`. The old cast is prefix like `cast(type) expression`. We need to support both of them now.
-
-            if !is_token(parser.lexer, #char ")") {
-                _cast.expression = parse(parser, _cast);
+        if !_cast.postfix {
+            if maybe_eat_token(parser.lexer, #char ",") {
+                _cast.function_style = true; // New cast is function like `cast(type, expression)`. The old cast is prefix like `cast(type) expression`. We need to support both of them now.
+                if !is_token(parser.lexer, #char ")") {
+                    _cast.expression = parse(parser, _cast);
+                }
             }
+        }
 
-            while is_token(parser.lexer, #char ",") {
-                parse_modifier();
-            }
+        while is_token(parser.lexer, #char ",") {
+            parse_modifier();
         }
 
         eat_token(parser.lexer, #char ")");
     }
 
-    if !_cast.function_style {
+    if !_cast.postfix && !_cast.function_style {
         _cast.expression = parse(parser, _cast);
+    }
+
+    // NOTE: For cases like a.(*int).* or cast(*int, a).* or a := b.(float) * 0.5 etc.
+    if _cast.postfix || _cast.function_style {
+        // Binary operation
+        if is_operator(peek_token(parser.lexer)) {
+            return parse_binary_operation(parser, _cast);
+        }
     }
 
     return _cast;

--- a/parser.jai
+++ b/parser.jai
@@ -1360,8 +1360,9 @@ parse_node :: (parser: *Parser, parent: *Node) -> *Node {
             return parse_identifier(parser, ident);
         }
 
+        equals_with_comma := is_token(parser.lexer, #char "=") && is_token(parser.lexer, #char ",", 1);
         // Binary operation
-        if is_operator(peek_token(parser.lexer)) && !is_token(parser.lexer, #char "=") && !parser.inside_compound_declaration {
+        if is_operator(peek_token(parser.lexer)) && !equals_with_comma && !parser.inside_compound_declaration {
             return parse_binary_operation(parser, parse_identifier(parser, ident));
         }
 

--- a/parser.jai
+++ b/parser.jai
@@ -460,9 +460,10 @@ Literal :: struct {
 
     value_type: Value_Type;
 
+    // NOTE: _string is separated from the union for the same reason as in Token. See the note there.
+    _string:  string;
     using values: union {
-        _string:  string;
-        _float:   float;
+        _float:   float64;
         _int:     int;
         _bool:    bool;
 
@@ -2672,15 +2673,14 @@ parse_literal :: (parser: *Parser) -> *Node {
             literal.value_type = .BOOL;
             literal._bool = false;
         case .NUMBER;
-            // @TODO: This is temporary solution!! Fix this :number_types:
             literal._string = base_literal.string_value;
-
-            if base_literal.integer_value == 0 {
+            kind := base_literal.number_kind;
+            if kind == .FLOAT || kind == .HEX_FLOAT || kind == .SCIENTIFIC_FLOAT {
                 literal.value_type = .FLOAT;
-                // literal._float = base_literal.float_value; // @TODO: Bug!!!
+                literal._float = base_literal.float_value;
             } else {
                 literal.value_type = .INT;
-                // literal._int = base_literal.integer_value;
+                literal._int = base_literal.integer_value;
             }
     }
 

--- a/parser.jai
+++ b/parser.jai
@@ -677,6 +677,7 @@ Comma_Separated_Expression :: struct {
     kind = .COMMA_SEPARATED_EXPRESSION;
 
     members: []*Node;
+    surrounded_with_parens: bool;
 }
 
 Directive_Run :: struct {
@@ -1758,6 +1759,7 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
 
         // Comma Separated Expression @TODO: maybe move this somewhere else?
         comma_separated_expression := New(Comma_Separated_Expression);
+        comma_separated_expression.surrounded_with_parens = true;
 
         comma_separated_expression.members = members;
         for comma_separated_expression.members it.parent = comma_separated_expression;

--- a/parser.jai
+++ b/parser.jai
@@ -1118,7 +1118,6 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
         is_compound_declaration: bool;
         final_token := peek_token(parser.lexer);
         default_compound_declaration_item_kind: Compound_Declaration_Item.Item_Kind;
-        // NOTE: Don't eat : or := because parse_type_instantiation and parse_declaration_and_assign will do that
         if maybe_eat_token(parser.lexer, #char ":") || 
            maybe_eat_token(parser.lexer, .DECLARATION_AND_ASSIGN) ||
            maybe_eat_token(parser.lexer, .CONSTANT_DECLARATION) {

--- a/parser.jai
+++ b/parser.jai
@@ -197,6 +197,7 @@ Cast :: struct {
     kind = .CAST;
 
     auto: bool;
+    function_style: bool;
 
     expression: *Node;
     cast_expression: *Node;
@@ -3099,8 +3100,7 @@ parse_cast :: (parser: *Parser, auto: bool = false) -> *Cast {
 
     eat_token(parser.lexer, ifx auto then Token.Kind.KEYWORD_AUTO_CAST else Token.Kind.KEYWORD_CAST);
 
-    // modifiers
-    if is_token(parser.lexer, #char ",") {
+    parse_modifier :: () #expand {
         eat_token(parser.lexer, #char ",");
 
         modifier := eat_token(parser.lexer, .IDENTIFIER);
@@ -3115,23 +3115,30 @@ parse_cast :: (parser: *Parser, auto: bool = false) -> *Cast {
         }
     }
 
-    new_cast: bool; // New cast is function like `cast(type, expression)`. The old cast is prefix like `cast(type) expression`. We need to support both of them now.
+    // modifiers
+    while is_token(parser.lexer, #char ",") {
+        parse_modifier();
+    }
 
     if !auto && maybe_eat_token(parser.lexer, #char "(") {
         _cast.cast_expression = parse(parser, _cast);
 
         if maybe_eat_token(parser.lexer, #char ",") {
-            new_cast = true;
+            _cast.function_style = true; // New cast is function like `cast(type, expression)`. The old cast is prefix like `cast(type) expression`. We need to support both of them now.
 
             if !is_token(parser.lexer, #char ")") {
                 _cast.expression = parse(parser, _cast);
+            }
+
+            while is_token(parser.lexer, #char ",") {
+                parse_modifier();
             }
         }
 
         eat_token(parser.lexer, #char ")");
     }
 
-    if !new_cast {
+    if !_cast.function_style {
         _cast.expression = parse(parser, _cast);
     }
 

--- a/parser.jai
+++ b/parser.jai
@@ -992,7 +992,7 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
     }
 
     // Comma Separated Expression, Compound Declaration ...
-    if (parent == null || can_contain_comma_separated_expression(parent.kind)) && is_start_of_comma_separated(parser.lexer) {
+    if (parent == null || can_contain_comma_separated_expression(parent.kind)) && !parser.inside_proc_args && is_start_of_comma_separated(parser.lexer) {
         unprocessed_tokens: [..]Token;
         nodes: [..] *Node;
 

--- a/parser.jai
+++ b/parser.jai
@@ -99,7 +99,6 @@ Note :: struct {
     using #as node: Node;
     kind = .NOTE;
 
-    name: string;
     value: string;
 }
 
@@ -3194,37 +3193,11 @@ parse_notes :: (parser: *Parser, parent: *Node, notes: *[..]*Note) {
 parse_note :: (parser: *Parser, parent: *Node) -> *Note  {
     note_token := eat_token(parser.lexer, .NOTE);
     note := New(Note);
-    note.name = note_token.string_value;
+    note.value = note_token.string_value;
     note.parent = parent;
 
     set_start_location(note, note_token);
-
-    if maybe_eat_token(parser.lexer, #char "(") {
-        builder: String_Builder;
-
-        // @TODO: This is ugly
-        while !end(parser.lexer) && !is_token(parser.lexer, #char ")") {
-            token := eat_token(parser.lexer);
-
-            if token.kind < 256 {
-                append(*builder, cast(u8) token.kind);
-                continue;
-            }
-
-            if token.kind == .STRING || token.kind == .NUMBER || token.kind == .DIRECTIVE || token.kind == .NOTE || token.kind == .IDENTIFIER {
-                append(*builder, token.string_value);
-                continue;
-            }
-
-            // @TODO: Operators!
-            append(*builder, enum_value_to_name(token.kind));
-        }
-
-        note.value = builder_to_string(*builder);
-        maybe_eat_token(parser.lexer, #char ")");
-    }
-
-    set_end_location(note, peek_token(parser.lexer, -1));
+    set_end_location(note, note_token);
 
     return note;
 }

--- a/parser.jai
+++ b/parser.jai
@@ -669,6 +669,7 @@ Directive_Run :: struct {
     stallable: bool;
     host: bool;
     expression: *Node;
+    returns: []*Return_Value;
 }
 
 Directive_Char :: struct {
@@ -1638,6 +1639,46 @@ parse_declaration_and_assign :: (parser: *Parser, ident_token: *Token) -> *Decla
     return decl;
 }
 
+parse_procedure_returns :: (parser: *Parser, parent: *Node) -> [..]*Return_Value
+{
+    starts_with_bracket := maybe_eat_token(parser.lexer, #char "(");
+    returns: [..]*Return_Value;
+
+    is_returns_end_token :: (token: *Token) -> bool {
+        if token.kind == #char ";" return true;
+        if token.kind == #char ")" return true;
+        if token.kind == #char "{" return true;
+        if token.kind == .DIRECTIVE return true;
+        return false;
+    }
+
+    while !end(parser.lexer) && !is_token(parser.lexer, is_returns_end_token) {
+        if maybe_eat_token(parser.lexer, #char ",") continue;
+
+        expression := parse(parser, parent);
+        if !expression continue;
+
+        return_value := New(Return_Value);
+        return_value.expression = expression;
+
+        if is_token(parser.lexer, t => t.kind == .DIRECTIVE && t.string_value == "must") {
+            eat_token(parser.lexer, .DIRECTIVE);
+            return_value.must = true;
+        }
+
+        array_add(*returns, return_value);
+
+        // If we are inside procedure args we take only one return if we are not in parentheses.
+        if !starts_with_bracket && parser.inside_proc_args {
+            break;
+        }
+    }
+
+    if starts_with_bracket maybe_eat_token(parser.lexer, #char ")");
+
+    return returns;
+}
+
 parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
     header_location: Node.Location;
     set_start_location(*header_location, peek_token(parser.lexer));
@@ -1700,47 +1741,13 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
 
     // returns
     if maybe_eat_token(parser.lexer, .ARROW_RIGHT) {
-        starts_with_bracket := maybe_eat_token(parser.lexer, #char "(");
-        returns: [..]*Return_Value;
-
-        is_returns_end_token :: (token: *Token) -> bool {
-            if token.kind == #char ";" return true;
-            if token.kind == #char ")" return true;
-            if token.kind == #char "{" return true;
-            if token.kind == .DIRECTIVE return true;
-            return false;
-        }
-
-        while !end(parser.lexer) && !is_token(parser.lexer, is_returns_end_token) {
-            if maybe_eat_token(parser.lexer, #char ",") continue;
-
-            expression := parse(parser, proc);
-            if !expression continue;
-
-            return_value := New(Return_Value);
-            return_value.expression = expression;
-
-            if is_token(parser.lexer, t => t.kind == .DIRECTIVE && t.string_value == "must") {
-                eat_token(parser.lexer, .DIRECTIVE);
-                return_value.must = true;
-            }
-
-            array_add(*returns, return_value);
-
-            // If we are inside procedure args we take only one return if we are not in parentheses.
-            if !starts_with_bracket && parser.inside_proc_args {
-                break;
-            }
-        }
-
+        returns := parse_procedure_returns(parser, proc);
         // If the last return value is must all the returns must be consumed.
         if returns.count > 0 && returns[returns.count-1].must {
             proc.flags |= .MUST_CONSUME_ALL_RETURNS;
         }
 
         proc.returns = returns;
-
-        if starts_with_bracket maybe_eat_token(parser.lexer, #char ")");
     }
 
     set_end_location(*header_location, peek_token(parser.lexer, -1));
@@ -2129,6 +2136,11 @@ parse_directive_run :: (parser: *Parser) -> *Directive_Run {
 
     //     directive_run.stallable = true;
     // }
+
+    if maybe_eat_token(parser.lexer, .ARROW_RIGHT) {
+        returns := parse_procedure_returns(parser, directive_run);
+        directive_run.returns = returns;
+    }
 
     directive_run.expression = parse(parser, directive_run);
 

--- a/parser.jai
+++ b/parser.jai
@@ -281,6 +281,7 @@ Procedure :: struct {
     foreign_alias: string;
     elsewhere: string;
     intrinsic: string;
+    intrinsic_is_string: bool;
     deprecated_note: string;
 
     flags: Flags;
@@ -1780,6 +1781,9 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
                 proc.flags |= .INTRINSIC;
                 if is_token(parser.lexer, .IDENTIFIER) {
                     proc.intrinsic = eat_token(parser.lexer, .IDENTIFIER).string_value;
+                } else if is_token(parser.lexer, .STRING) {
+                    proc.intrinsic = eat_token(parser.lexer, .STRING).string_value;
+                    proc.intrinsic_is_string = true;
                 }
 
             case "compiler";

--- a/parser.jai
+++ b/parser.jai
@@ -3070,8 +3070,9 @@ parse_if :: (parser: *Parser, kind: If.If_Kind = .UNKNOWN, compile_time := false
 
         then_found, then_token := maybe_eat_token(parser.lexer, .KEYWORD_THEN);
         _if.then_keyword_used = then_found;
-        // NOTE: In ifx we only want to parse _then if the 'then' keyword was actually used. For ifx with implicit 'then' _then will be empty because the condition is also treated as _then.
-        if _if.if_kind == .IF || (_if.if_kind == .IFX && then_found) {
+        parse_then := then_found || !is_token(parser.lexer, .KEYWORD_ELSE);
+
+        if _if.if_kind == .IF || (_if.if_kind == .IFX && parse_then) {
             _if._then = parse(parser, _if);
         }
 

--- a/parser.jai
+++ b/parser.jai
@@ -3090,7 +3090,7 @@ parse_push_context :: (parser: *Parser) -> *Push_Context {
     _push_context.pushed = parse(parser, _push_context);
 
     // @TODO: Block only?
-    if is_token(parser.lexer, #char "{") {
+    if !_push_context.defer_pop && is_token(parser.lexer, #char "{") {
         _push_context.block = parse_block(parser);
         _push_context.block.parent = _push_context;
     }

--- a/parser.jai
+++ b/parser.jai
@@ -3132,9 +3132,14 @@ parse_inline_assembly :: (parser: *Parser) -> *Inline_Assembly {
         inline_assembly.expression = parse(parser, inline_assembly);
     }
 
-    eat_token(parser.lexer, #char "{");
+    block_start := eat_token(parser.lexer, #char "{");
     while !is_token(parser.lexer, #char "}") eat_token(parser.lexer);
-    eat_token(parser.lexer, #char "}");
+    block_end := eat_token(parser.lexer, #char "}");
+
+    start_string := block_start.string_value.data;
+    end_string := block_end.string_value.data;
+    inline_assembly.body.data = start_string;
+    inline_assembly.body.count = end_string - start_string + 1; // NOTE: +1 to include the '}'.
 
     return inline_assembly;
 }

--- a/parser.jai
+++ b/parser.jai
@@ -292,6 +292,7 @@ Procedure :: struct {
     flags: Flags;
     arguments: []*Node;
     returns: []*Return_Value;
+    returns_surrounded_with_parens: bool;
     modify_block: *Block;
     body: *Block;
     notes: [] *Note;
@@ -688,6 +689,7 @@ Directive_Run :: struct {
     host: bool;
     expression: *Node;
     returns: []*Return_Value;
+    returns_surrounded_with_parens: bool;
 }
 
 Directive_Char :: struct {
@@ -1681,7 +1683,7 @@ parse_declaration_and_assign :: (parser: *Parser, ident_token: *Token, first_ope
     return decl;
 }
 
-parse_procedure_returns :: (parser: *Parser, parent: *Node) -> [..]*Return_Value
+parse_procedure_returns :: (parser: *Parser, parent: *Node) -> [..]*Return_Value, bool
 {
     starts_with_bracket := maybe_eat_token(parser.lexer, #char "(");
     returns: [..]*Return_Value;
@@ -1718,7 +1720,7 @@ parse_procedure_returns :: (parser: *Parser, parent: *Node) -> [..]*Return_Value
 
     if starts_with_bracket maybe_eat_token(parser.lexer, #char ")");
 
-    return returns;
+    return returns, starts_with_bracket;
 }
 
 parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
@@ -1784,12 +1786,13 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
 
     // returns
     if maybe_eat_token(parser.lexer, .ARROW_RIGHT) {
-        returns := parse_procedure_returns(parser, proc);
+        returns, surrounded_with_parens := parse_procedure_returns(parser, proc);
         // If the last return value is must all the returns must be consumed.
         if returns.count > 0 && returns[returns.count-1].must {
             proc.flags |= .MUST_CONSUME_ALL_RETURNS;
         }
 
+        proc.returns_surrounded_with_parens = surrounded_with_parens;
         proc.returns = returns;
     }
 
@@ -2218,8 +2221,9 @@ parse_directive_run :: (parser: *Parser) -> *Directive_Run {
     // }
 
     if maybe_eat_token(parser.lexer, .ARROW_RIGHT) {
-        returns := parse_procedure_returns(parser, directive_run);
+        returns, surrounded_with_parens := parse_procedure_returns(parser, directive_run);
         directive_run.returns = returns;
+        directive_run.returns_surrounded_with_parens = surrounded_with_parens;
     }
 
     directive_run.expression = parse(parser, directive_run);

--- a/parser.jai
+++ b/parser.jai
@@ -946,7 +946,7 @@ Inline_Assembly :: struct {
 parse :: (parser: *Parser, parent: *Node) -> *Node {
     current_token := peek_token(parser.lexer);
 
-    base_node := parse_node(parser);
+    base_node := parse_node(parser, parent);
     if !base_node return null;
     base_node.parent = parent;
 
@@ -1317,7 +1317,7 @@ create_operator_from_token :: (using token: Token) -> _Operator {
     return .INVALID;
 }
 
-parse_node :: (parser: *Parser) -> *Node {
+parse_node :: (parser: *Parser, parent: *Node) -> *Node {
 
     // Declaration, Binary Operation, Unary Operation, Identifier
     if is_identifier(parser.lexer) {
@@ -1326,6 +1326,11 @@ parse_node :: (parser: *Parser) -> *Node {
         // struct or array literal
         if is_token(parser.lexer, .BEGIN_STRUCT_LITERAL) || is_token(parser.lexer, .BEGIN_ARRAY_LITERAL) {
             return parse_array_or_struct_literal(parser, parse_identifier(parser, ident));
+        }
+
+        // Interface restriction in polymorphic constants. Without this check $T/interface X is parsed as a binary operation.
+        if is_token(parser.lexer, #char "/") && parent && parent.kind == .POLYMORPHIC_CONSTANT {
+            return parse_identifier(parser, ident);
         }
 
         // Binary operation

--- a/parser.jai
+++ b/parser.jai
@@ -111,6 +111,7 @@ Declaration :: struct {
     const: bool;
     has_elsewhere: bool;
     elsewhere: string;
+    elsewhere_alias: string;
     type_inst: *Node;
     expression: *Node;
     backticked: bool;
@@ -280,6 +281,7 @@ Procedure :: struct {
     foreign_lib: string;
     foreign_alias: string;
     elsewhere: string;
+    elsewhere_alias: string;
     intrinsic: string;
     intrinsic_is_string: bool;
     deprecated_note: string;
@@ -1587,6 +1589,9 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
         decl.has_elsewhere = true;
         if is_token(parser.lexer, .IDENTIFIER) {
             decl.elsewhere = eat_token(parser.lexer, .IDENTIFIER).string_value;
+            if is_token(parser.lexer, .STRING) {
+                decl.elsewhere_alias = eat_token(parser.lexer, .STRING).string_value;
+            }
         }
     }
     
@@ -1791,6 +1796,9 @@ parse_procedure :: (parser: *Parser, force_procedure := false) -> *Node {
             case "elsewhere";
                 proc.flags |= .ELSEWHERE;
                 proc.elsewhere = eat_token(parser.lexer, .IDENTIFIER).string_value;
+                if is_token(parser.lexer, .STRING) {
+                    proc.elsewhere_alias = eat_token(parser.lexer, .STRING).string_value;
+                }
             case "foreign";
                 proc.flags |= .FOREIGN;
 

--- a/parser.jai
+++ b/parser.jai
@@ -1579,7 +1579,6 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
         decl.expression = parse(parser, decl);
     }
 
-    // maybe_eat_token(parser.lexer, #char ";");
 
     if maybe_eat_token(parser.lexer, t => t.kind == .DIRECTIVE && t.string_value == "elsewhere") {
         decl.has_elsewhere = true;
@@ -1587,6 +1586,9 @@ parse_type_instantiation :: (parser: *Parser, ident_token: *Token) -> *Declarati
             decl.elsewhere = eat_token(parser.lexer, .IDENTIFIER).string_value;
         }
     }
+    
+    // NOTE: Notes in declarations are after the semicolon
+    maybe_eat_token(parser.lexer, #char ";");
 
     // Notes
     if is_token(parser.lexer, .NOTE) {


### PR DESCRIPTION
- [x] The interface restriction is not parsing correctly: when parsing test :: (a: $T/interface X) {} the restrictions_interface flag is not set to true.
- [x] When parsing inline assembly the body is empty.
- [x] When using push_contex,defer_pop the block variable shouldn't be set. If there is a block after push_context,defer_pop it should be parsed as a separate node.
- [x] The left side of the = operator in a:, b = 1, 2 and a, b = 1, 2 is parsed as a comma separated expression instead of a compound declaration.
- [x] a :: #run -> string { return "a"; } is not parsing correctly and the expression is set to null.
- [x] no_parameters in using is never set.
- [x] There is no way to tell if a comment is single or multi line.
- [x] The #v2 directive in for is ignored
- [x] There is no way to tell if an if statement had a then keyword used.
- [x] In a := ifx b else c; else is ignored.
- [x] In if true then print("true"); else print("false"); else is ignored.
- [x] Intrinsic names are not parsed when they are in quotes. For example#intrinsic "llvm.debugtrap" in Runtime_Support.jai.
- [x] #elsewhere can have an alias after the library name just like #foreign. For example stdin: *FILE #elsewhere libc "__stdinp"; in POSIX/bindings/macos/arm64/stdio.jai. Currently the parser ignores the alias.
- [x] Postfix casts are parsed as comma separated expressions.
- [x] Function style casts are parsed incorrectly and produce an error: token ',' != required ')'. For example a := cast( *u8, b, trunc, force );
- [x] The separation of notes into name and value doesn't really make sense because the notes can have different structures. For example @Note:value, @Test-Note{value=1}, @Note[0] are all valid notes but won't be parsed correctly.
- [x] Unary operator EXPAND is not used anywhere.
- [x] There is no way to tell if a string literal is a here string or a normal string.