### PR TITLE
Two small fixes

### DIFF
--- a/parser.jai
+++ b/parser.jai
@@ -4,7 +4,6 @@ Parser :: struct(User_Data_Type: Type) {
     user_data: User_Data_Type;
     inside_proc_args: bool;
     inside_proc_returns: bool;
-    inside_compound_declaration: bool;
 }
 
 Node :: struct {
@@ -1139,7 +1138,6 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
 
         if is_compound_declaration {
             compound_declaration := New(Compound_Declaration);
-            parser.inside_compound_declaration = true;
 
             transform_nodes_into_items(compound_declaration, nodes_types, nodes, default_compound_declaration_item_kind);
 
@@ -1161,7 +1159,6 @@ parse :: (parser: *Parser, parent: *Node) -> *Node {
             set_end_location(compound_declaration, peek_token(parser.lexer, -1));
             parser.node_visit(compound_declaration, parser.user_data);
 
-            parser.inside_compound_declaration = false;
             return compound_declaration;
         }
 
@@ -1368,7 +1365,7 @@ parse_node :: (parser: *Parser, parent: *Node) -> *Node {
 
         equals_with_comma := is_token(parser.lexer, #char "=") && is_token(parser.lexer, #char ",", 1);
         // Binary operation
-        if is_operator(peek_token(parser.lexer)) && !equals_with_comma && !parser.inside_compound_declaration {
+        if is_operator(peek_token(parser.lexer)) && !equals_with_comma {
             return parse_binary_operation(parser, parse_identifier(parser, ident));
         }
 
@@ -1396,7 +1393,7 @@ parse_node :: (parser: *Parser, parent: *Node) -> *Node {
             return parse_declaration_and_assign(parser, ident);
         }
 
-        if is_token(parser.lexer, #char ":") && !is_token(parser.lexer, #char ",", 1) && !parser.inside_compound_declaration {
+        if is_token(parser.lexer, #char ":") && !is_token(parser.lexer, #char ",", 1) {
             return parse_type_instantiation(parser, ident);
         }
 

--- a/parser.jai
+++ b/parser.jai
@@ -407,7 +407,8 @@ Directive_Import :: struct {
         STRING;
     }
 
-    arguments: []*Node;
+    module_parameters: []*Node;
+    program_parameters: []*Node;
     import_kind: Import_Kind;
     module: string;
 }
@@ -819,9 +820,8 @@ Directive_Module_Parameters :: struct {
     using #as node: Node;
     kind = .DIRECTIVE_MODULE_PARAMETERS;
 
-    // @TODO: rename this (currently we don't know why does the directive have double parameters)
-    parameters: [] *Node;
-    second_parameters: [] *Node;
+    module_parameters: []*Node;
+    program_parameters: []*Node;
 }
 
 Directive_Placeholder :: struct {
@@ -2301,7 +2301,11 @@ parse_directive_import :: (parser: *Parser) -> *Directive_Import {
     directive_import.module = eat_token(parser.lexer, .STRING).string_value;
 
     if is_token(parser.lexer, #char "(") {
-        directive_import.arguments = delimeted(parser, #char "(", #char ")", #char ",", directive_import);
+        directive_import.module_parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_import);
+    }
+
+    if is_token(parser.lexer, #char "(") {
+        directive_import.program_parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_import);
     }
 
     return directive_import;
@@ -2466,11 +2470,11 @@ parse_directive_module_parameters :: (parser: *Parser) -> *Directive_Module_Para
     directive_module_parameters := New(Directive_Module_Parameters);
 
     if is_token(parser.lexer, #char "(") {
-        directive_module_parameters.parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_module_parameters);
+        directive_module_parameters.module_parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_module_parameters);
     }
 
     if is_token(parser.lexer, #char "(") {
-        directive_module_parameters.second_parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_module_parameters);
+        directive_module_parameters.program_parameters = delimeted(parser, #char "(", #char ")", #char ",", directive_module_parameters);
     }
 
     return directive_module_parameters;


### PR DESCRIPTION
Hi.
Just two more small fixes:
- I removed the `inside_compound_declaration` flag because it was causing problems in cases like `ok, left, right := split_from_left(it.file, #char ".");`. There where a lot of changes to the compound declaration parsing and I honestly don't remember why I added this flag 😄 . It seems that the declarations are parsing correctly without it.
- I fixed parsing of the module parameters for `Directive_Import` - it can have two sets of parameters just like `#module_parameters`

Regarding that TODO about module parameters directive the first set is called 'module parameters' and the second is called 'program parameters'. The first one can have different values for different imports for example you can have `Software_Simp :: #import "Simp"(render_api = .SOFTWARE);` and `Opengl_Simp :: #import "Simp"(render_api = .OPENGL);` in one program. But program parameters are global for all imports of that module and can only be set once. For example you can only have one `Basic :: #import "Basic"()(ENABLE_ASSERT = false);` and then if you import more basics (`Basic2 :: #import "Basic";`) they will all have `ENABLE_ASSERT` set to `false`