### PR TITLE
Fixes for operator procedure calls and default values of function pointers

### DIFF
--- a/parser.jai
+++ b/parser.jai
@@ -989,6 +989,7 @@ parse :: (parser: *Parser, parent: *Node, no_comma_separated := false) -> *Node 
         if kind == .WHILE return true;
         if kind == .COMPOUND_DECLARATION return true;
         if kind == .DECLARATION return true;
+        if kind == .DIRECTIVE_SCOPE return true;
         // if kind == .STRUCT return true;
         // if kind == .ENUM return true;
         // if kind == .UNION return true;


### PR DESCRIPTION
Hi.

Some more fixes for:
- calling operator overloads like this: `operator==(a, b)`. This is useful for example for doing: `node_equals :: #procedure_of_call operator==(Node.{}, Node.{});`
- parsing the default value of a function pointer. Previously in `S :: struct(proc: (a: int) -> bool = null)` the `bool = null` would be parsed as a binary operation and treated like a return value.
- minor typos: delimeted -> delimited, seperator -> separator