### PR TITLE
Fix parsing union tag and notes

### DIFF
--- a/parser.jai
+++ b/parser.jai
@@ -2125,14 +2125,14 @@ parse_union :: (parser: *Parser) -> *Union {
         _union.polymorphic_arguments = delimited(parser, #char "(", #char ")", #char ",", _union);
     }
 
+    notes: [..] *Note;
+    if is_token(parser.lexer, .NOTE) {
+        parse_notes(parser, _union, *notes);
+    }
+
     // Tagged Union tag
-    if is_token(parser.lexer, .IDENTIFIER) {
-    	ident := eat_token(parser.lexer, .IDENTIFIER);
-     	if ident.string_value == "kind" && is_token(parser.lexer, #char ":") {
-      		if maybe_eat_token(parser.lexer, #char ":") {
-        		_union.tag = parse(parser, _union);
-        	}
-      	}
+    if is_token(parser.lexer, .IDENTIFIER) || is_token(parser.lexer, .KEYWORD_ENUM) {
+        _union.tag = parse(parser, _union);
     }
 
     if is_token(parser.lexer, #char "{") {
@@ -2151,10 +2151,10 @@ parse_union :: (parser: *Parser) -> *Union {
     }
 
     if is_token(parser.lexer, .NOTE) {
-        notes: [..] *Note;
         parse_notes(parser, _union, *notes);
-        _union.notes = notes;
     }
+
+    _union.notes = notes;
 
     return _union;
 }


### PR DESCRIPTION
Hi.

There are two changes here:
- Fixed parsing notes on unions to work the same way as on structs and enums - allow notes after the `union` keyword and after the block
- Fixed parsing of the new tag feature. Before the tag was only parsed if it was named `kind` which is not correct because it can have any valid name. The tag can also be a anonymous enum like this:
```jai
Test_Union :: union tag: enum
{
    A;
    B;
    C;
}
{
    a: int;
    b: float;
    c: string;
}
```