### PR TITLE
Fix parsing struct literals without dot in binary operations

### DIFF
--- a/parser.jai
+++ b/parser.jai
@@ -3223,8 +3223,8 @@ parse_binary_operation :: (parser: *Parser, left: *Node) -> *Node {
     assert(is_operator(op));
     binary_operation.operation = create_operator_from_token(op);
 
-    // Guard?
-    if is_token(parser.lexer, #char "{") || is_token(parser.lexer, #char "}") {
+    // NOTE: In 'if a == {' don't parse the block
+    if is_token(parser.lexer, #char "{") && binary_operation.operation == .IS_EQUAL {
         return binary_operation;
     }
 


### PR DESCRIPTION
Hi.

Just a small change that fixes parsing the new struct literals without dot in binary operations. For example in this:
```jai
position: Vector3;
position = {0, 0, 0};
```
the struct literal would be parsed as a block and not part of the binary operation.