### PR TITLE
Fix parsing struct literals for polymorphic structs

### DIFF
--- a/parser.jai
+++ b/parser.jai
@@ -2300,6 +2300,10 @@ parse_procedure_call :: (parser: *Parser, procedure: *Node) -> *Node {
         return parse_binary_operation(parser, proc_call);
     }
 
+    if is_token(parser.lexer, .BEGIN_STRUCT_LITERAL) {
+         return parse_array_or_struct_literal(parser, proc_call);
+    }
+
     return proc_call;
 }
 


### PR DESCRIPTION
Hi.

In a case like this: `a := Struct(5).{}` the `Struct(5)` was being parsed as a procedure call and `.{}` was being parsed as a separate struct literal without a type. Now it's being parsed correctly but the `type` on the `Struct_Literal_Info` is still set to `Procedure_Call` - this is fine for my formatter but for LSP use you might want to change that.